### PR TITLE
适配链接管理 2.2.x：修复 LinkageError 启动崩溃并防止友链数据丢失

### DIFF
--- a/src/main/java/com/kunkunyu/link/submit/extension/Link.java
+++ b/src/main/java/com/kunkunyu/link/submit/extension/Link.java
@@ -1,20 +1,39 @@
 package com.kunkunyu.link.submit.extension;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 @GVK(group = "core.halo.run", version = "v1alpha1", kind = "Link", plural = "links", singular = "link")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Link extends AbstractExtension {
 
     private LinkSpec spec;
 
+    private Map<String, Object> additionalProperties = new LinkedHashMap<>();
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String key, Object value) {
+        this.additionalProperties.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
     @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class LinkSpec {
         @Schema(required = true)
         private String url;
@@ -29,5 +48,17 @@ public class Link extends AbstractExtension {
         private Integer priority;
 
         private String groupName;
+
+        private Map<String, Object> additionalProperties = new LinkedHashMap<>();
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+        }
+
+        @JsonAnyGetter
+        public Map<String, Object> getAdditionalProperties() {
+            return additionalProperties;
+        }
     }
 }

--- a/src/main/java/com/kunkunyu/link/submit/extension/LinkGroup.java
+++ b/src/main/java/com/kunkunyu/link/submit/extension/LinkGroup.java
@@ -1,26 +1,55 @@
 package com.kunkunyu.link.submit.extension;
 
-import io.swagger.v3.oas.annotations.media.ArraySchema;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import run.halo.app.extension.AbstractExtension;
 import run.halo.app.extension.GVK;
-import java.util.LinkedHashSet;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 @GVK(group = "core.halo.run", version = "v1alpha1", kind = "LinkGroup", plural = "linkgroups", singular = "linkgroup")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LinkGroup extends AbstractExtension {
 
     private LinkGroupSpec spec;
 
+    private Map<String, Object> additionalProperties = new LinkedHashMap<>();
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String key, Object value) {
+        this.additionalProperties.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
     @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class LinkGroupSpec {
         @Schema(required = true)
         private String displayName;
 
         private Integer priority;
+
+        private Map<String, Object> additionalProperties = new LinkedHashMap<>();
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String key, Object value) {
+            this.additionalProperties.put(key, value);
+        }
+
+        @JsonAnyGetter
+        public Map<String, Object> getAdditionalProperties() {
+            return additionalProperties;
+        }
     }
 }

--- a/src/main/java/com/kunkunyu/link/submit/service/impl/LinkServiceImpl.java
+++ b/src/main/java/com/kunkunyu/link/submit/service/impl/LinkServiceImpl.java
@@ -1,6 +1,5 @@
 package com.kunkunyu.link.submit.service.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,10 +21,9 @@ import run.halo.app.extension.Metadata;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.extension.Unstructured;
 import run.halo.app.extension.router.selector.FieldSelector;
+import run.halo.app.infra.utils.JsonUtils;
 
 import static org.springframework.data.domain.Sort.Order.asc;
-import static org.springframework.data.domain.Sort.Order.desc;
-
 
 @Service
 @RequiredArgsConstructor
@@ -34,9 +32,6 @@ public class LinkServiceImpl implements LinkService {
     private final ReactiveExtensionClient client;
 
     private final SettingConfigLinkSubmit settingConfigLinkSubmit;
-
-    private final ObjectMapper objectMapper = Unstructured.OBJECT_MAPPER;
-
 
     @Override
     public Mono<Link> getName(String name) {
@@ -50,7 +45,6 @@ public class LinkServiceImpl implements LinkService {
         return client.listAll(LinkGroup.class, listOptions, defaultLinkSort())
             .map(LinkGroupVo::from);
     }
-
 
     public Flux<Link> listLink() {
         var listOptions = new ListOptions();
@@ -106,12 +100,11 @@ public class LinkServiceImpl implements LinkService {
     }
 
     private Mono<Link> createByUnstructured(Link link) {
-        Map extensionMap = objectMapper.convertValue(link, Map.class);
+        Map extensionMap = JsonUtils.mapper().convertValue(link, Map.class);
         var extension = new Unstructured(extensionMap);
-        return client.create(extension).flatMap(unstructured -> {
-            var linkNew = objectMapper.convertValue(unstructured, Link.class);
-            return Mono.just(linkNew);
-        });
+        return client.create(extension).map(unstructured -> 
+            JsonUtils.mapper().convertValue(unstructured, Link.class)
+        );
     }
 
     public Mono<Link> delete(Link link) {
@@ -119,22 +112,20 @@ public class LinkServiceImpl implements LinkService {
     }
 
     private Mono<Link> deleteByUnstructured(Link link) {
-        Map extensionMap = objectMapper.convertValue(link, Map.class);
+        Map extensionMap = JsonUtils.mapper().convertValue(link, Map.class);
         var extension = new Unstructured(extensionMap);
-        return client.delete(extension).flatMap(unstructured -> {
-            var linkDel = objectMapper.convertValue(unstructured, Link.class);
-            return Mono.just(linkDel);
-        });
+        return client.delete(extension).map(unstructured -> 
+            JsonUtils.mapper().convertValue(unstructured, Link.class)
+        );
     }
 
     @Override
     public Mono<Link> update(Link link) {
-        Map extensionMap = objectMapper.convertValue(link, Map.class);
+        Map extensionMap = JsonUtils.mapper().convertValue(link, Map.class);
         var extension = new Unstructured(extensionMap);
-        return client.update(extension).flatMap(unstructured -> {
-            var linkNew = objectMapper.convertValue(unstructured, Link.class);
-            return Mono.just(linkNew);
-        });
+        return client.update(extension).map(unstructured -> 
+            JsonUtils.mapper().convertValue(unstructured, Link.class)
+        );
     }
 
     static Sort defaultLinkSort() {


### PR DESCRIPTION
## 问题背景

`plugin-links` 升级至 2.2.x 后新增了 RSS 订阅 (`spec.rss`)、链接探活检测 (`spec.verification`) 及状态反馈 (`status`) 等字段。`link-submit` 插件存在两个严重问题：

1. **启动报错 (`LinkageError`)**：`LinkServiceImpl` 中直接引用了 `Unstructured.OBJECT_MAPPER`，PF4J 类加载器在校验阶段发现与 Halo 主程序的 `ObjectMapper` 冲突，导致插件无法启动。
2. **致命数据丢失**：`Link.java` 模型未包含新字段，Jackson 反序列化时会丢弃所有未知字段，导致审核更新友链后 RSS 配置和存活检测数据被清空。

## 修改内容

### 1. `Link.java` — 兼容未知字段
- 类级别添加 `@JsonIgnoreProperties(ignoreUnknown = true)`
- 在 `Link` 和 `LinkSpec` 两层分别添加 `@JsonAnySetter` / `@JsonAnyGetter`，用 `LinkedHashMap` 捕获所有新增字段，保存时原封不动写回

### 2. `LinkGroup.java` — 兼容未知字段
- 同上处理，在 `LinkGroup` 和 `LinkGroupSpec` 两层添加动态字段捕获机制

### 3. `LinkServiceImpl.java` — 根除 LinkageError
- 移除 `private final ObjectMapper objectMapper = Unstructured.OBJECT_MAPPER`
- 全部改用 `JsonUtils.mapper()` 进行 JSON 转换
- `createByUnstructured` / `deleteByUnstructured` / `update` 中的 `.flatMap()` 简化为 `.map()`

## 测试jar包
[1.0.7-新的测试构建版本.jar.zip](https://github.com/user-attachments/files/29168916/1.0.7-.jar.zip)

